### PR TITLE
Added clarification / comments to setup scripts

### DIFF
--- a/configure-windows.ps1
+++ b/configure-windows.ps1
@@ -1,4 +1,29 @@
 
+ <#
+.SYNOPSIS  
+    Configures windows worker node
+.LINK  
+    https://github.com/bsteciuk/k8s-ovn-windows-cluster
+    https://kubernetes.io/docs/getting-started-guides/windows/
+.EXAMPLE  
+   > .\ovnkube.exe -k8s-apiserver https://172.20.2.30:6443  -k8s-cacert "C:\etc\kubernetes\pki\ca.crt" -init-node "win-gd0rkodikbq" -nb-address "tcp://172.20.2.30:6641" -sb-address "tcp://172.20.2.30:6642" -cluster-subnet "192.168.0.0/16" -cni-conf-dir "C:\cni-conf" -k8s-token "<token from kubeadm>"
+   > INFO[0000] Parsed config file C:\Program Files\Cloudbase Solutions\Open vSwitch\conf\\ovn_k8s.conf
+   > INFO[0000] Parsed config: {Default:{MTU:1500 ConntrackZone:64321} Logging:{File:C:\var\log\ovnkube.log Level:5} CNI:{ConfDir:C:\cni-conf Plugin:ovn-k8s-cni-overlay WinHNSNetworkID:} Kubernetes:{Kubeconfig: CACert:C:\etc\kubernetes\pki\ca.crt APIServer: Token:} OvnNorth:{Address: ClientPrivKey: ClientCert: ClientCACert: ServerPrivKey: ServerCert: ServerCACert:} OvnSouth:{Address: ClientPrivKey: ClientCert: ClientCACert: ServerPrivKey: ServerCert: ServerCACert:}}
+.FUNCTIONALITY  
+   Not sure How to specify or use  
+   Does not appear in basic, -full, or -detailed  
+   Should appear with -functionality  
+.PARAMETER gatewayIp  
+   The first IP on the ovnHostSubnet , e.g. 192.168.3.1
+.PARAMETER ovnHostSubnet  
+   The subnet that comes back from kubectl describe node "<WINDOWS_HOSTNAME>" | grep ovn_host_subnet
+   after the windows node is initialized, e.g. 192.168.3.0/24
+.PARAMETER networkInterfaceAlias  
+   The network interface name that is provisioned for the cluster , what
+   comes back from ipconfig for the "external" interface where this node is accessible
+   , e.g. "Ethernet 2"
+#>
+ 
  param (
     [Parameter(Mandatory=$true)][string]$gatewayIp,
     [Parameter(Mandatory=$true)][string]$ovnHostSubnet,

--- a/configure-windows.ps1
+++ b/configure-windows.ps1
@@ -6,9 +6,7 @@
     https://github.com/bsteciuk/k8s-ovn-windows-cluster
     https://kubernetes.io/docs/getting-started-guides/windows/
 .EXAMPLE  
-   > .\ovnkube.exe -k8s-apiserver https://172.20.2.30:6443  -k8s-cacert "C:\etc\kubernetes\pki\ca.crt" -init-node "win-gd0rkodikbq" -nb-address "tcp://172.20.2.30:6641" -sb-address "tcp://172.20.2.30:6642" -cluster-subnet "192.168.0.0/16" -cni-conf-dir "C:\cni-conf" -k8s-token "<token from kubeadm>"
-   > INFO[0000] Parsed config file C:\Program Files\Cloudbase Solutions\Open vSwitch\conf\\ovn_k8s.conf
-   > INFO[0000] Parsed config: {Default:{MTU:1500 ConntrackZone:64321} Logging:{File:C:\var\log\ovnkube.log Level:5} CNI:{ConfDir:C:\cni-conf Plugin:ovn-k8s-cni-overlay WinHNSNetworkID:} Kubernetes:{Kubeconfig: CACert:C:\etc\kubernetes\pki\ca.crt APIServer: Token:} OvnNorth:{Address: ClientPrivKey: ClientCert: ClientCACert: ServerPrivKey: ServerCert: ServerCACert:} OvnSouth:{Address: ClientPrivKey: ClientCert: ClientCACert: ServerPrivKey: ServerCert: ServerCACert:}}
+   .\configure-windows.ps1 -gatewayIp 192.168.3.1 -ovnHostSubnet 192.168.3.0/24 -networkInterfaceAlias "Ethernet 2"
 .FUNCTIONALITY  
    Not sure How to specify or use  
    Does not appear in basic, -full, or -detailed  

--- a/init.ps1
+++ b/init.ps1
@@ -1,4 +1,6 @@
 netsh advfirewall set AllProfiles state off
+# The netkvm commands will fail in a local install
+# These are relevant only if running in GCP
 netsh netkvm setparam 0 *RscIPv4 0
 netsh netkvm restart 0
 


### PR DESCRIPTION
Exmple output : 

------------
PS C:\tmp\k8s-setup> get-help C:\tmp\k8s-setup\configure-windows.ps1 -detailed

NAME
    C:\tmp\k8s-setup\configure-windows.ps1

SYNOPSIS
    Configures windows worker node


SYNTAX
    C:\tmp\k8s-setup\configure-windows.ps1 [-gatewayIp] <String> [-ovnHostSubnet] <String> [-networkInterfaceAlias] <String> [<CommonParameters>]


DESCRIPTION


PARAMETERS
    -gatewayIp <String>
        The first IP on the ovnHostSubnet , e.g. 192.168.3.1

    -ovnHostSubnet <String>
        The subnet that comes back from kubectl describe node "<WINDOWS_HOSTNAME>" | grep ovn_host_subnet
        after the windows node is initialized, e.g. 192.168.3.0/24

    -networkInterfaceAlias <String>
        The network interface name that is provisioned for the cluster , what
        comes back from ipconfig for the "external" interface where this node is accessible
        , e.g. "Ethernet 2"

    <CommonParameters>
        This cmdlet supports the common parameters: Verbose, Debug,
        ErrorAction, ErrorVariable, WarningAction, WarningVariable,
        OutBuffer, PipelineVariable, and OutVariable. For more information, see
        about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).

    -------------------------- EXAMPLE 1 --------------------------

    >.\ovnkube.exe -k8s-apiserver https://172.20.2.30:6443  -k8s-cacert "C:\etc\kubernetes\pki\ca.crt" -init-node "win-gd0rkodikbq" -nb-address "tcp://172.20.2.30:6641"
    -sb-address "tcp://172.20.2.30:6642" -cluster-subnet "192.168.0.0/16" -cni-conf-dir "C:\cni-conf" -k8s-token "<token from kubeadm>"

    > INFO[0000] Parsed config file C:\Program Files\Cloudbase Solutions\Open vSwitch\conf\\ovn_k8s.conf
    > INFO[0000] Parsed config: {Default:{MTU:1500 ConntrackZone:64321} Logging:{File:C:\var\log\ovnkube.log Level:5} CNI:{ConfDir:C:\cni-conf Plugin:ovn-k8s-cni-overlay
    WinHNSNetworkID:} Kubernetes:{Kubeconfig: CACert:C:\etc\kubernetes\pki\ca.crt APIServer: Token:} OvnNorth:{Address: ClientPrivKey: ClientCert: ClientCACert:
    ServerPrivKey: ServerCert: ServerCACert:} OvnSouth:{Address: ClientPrivKey: ClientCert: ClientCACert: ServerPrivKey: ServerCert: ServerCACert:}}




REMARKS
    To see the examples, type: "get-help C:\tmp\k8s-setup\configure-windows.ps1 -examples".
    For more information, type: "get-help C:\tmp\k8s-setup\configure-windows.ps1 -detailed".
    For technical information, type: "get-help C:\tmp\k8s-setup\configure-windows.ps1 -full".
    For online help, type: "get-help C:\tmp\k8s-setup\configure-windows.ps1 -online"
