### PR TITLE
Tweaked init script to pick up pre-build ovn-k8s binaries. 

### DIFF
--- a/build-ovn-kubernetes.sh
+++ b/build-ovn-kubernetes.sh
@@ -1,0 +1,18 @@
+# Run this script to biuld ovn-kubernetes
+# when you're done, put this into a release in github and update init.sh with the rev/URL of this build
+#Get, build, and install ovn-kubernetes
+mkdir -p .build
+cd .build
+git clone https://github.com/openvswitch/ovn-kubernetes
+
+cd ovn-kubernetes/go-controller
+
+#We are switching to PR with fixes for windows RTM
+git fetch origin pull/288/head:PR-288
+git checkout PR-288
+echo "Building ovn-kubernetes binaries... this may take a few minutes."
+make all
+
+ovnk8sVersion=$(git rev-parse --short HEAD)
+cd _output/go/
+tar -czvf ../../../../ovn-kubernetes-rev-${ovnk8sVersion}.tar.gz bin/* 

--- a/init.sh
+++ b/init.sh
@@ -74,9 +74,9 @@ mkdir -p /opt/ovn-kubernetes
 wget -q ${ovnk8sBinsUrl}
 tar -xvzf ${ovnk8sTarGz} -C /opt/ovn-kubernetes
 cp /opt/ovn-kubernetes/bin/ovnkube /usr/bin/
-cp /opt/ovn-kubernetes/bin/ovn-k8s-overlay /usr/bin/
+cp /opt/ovn-kubernetes/bin/ovn-k8s-overlay /opt/cni/bin/
 cp /opt/ovn-kubernetes/bin/ovn-kube-util /usr/bin/
-cp /opt/ovn-kubernetes/bin/ovn-k8s-cni-overlay -t /usr/bin/
+cp /opt/ovn-kubernetes/bin/ovn-k8s-cni-overlay /opt/cni/bin/
 
 
 #copy the cni config


### PR DESCRIPTION
Tweaked the init script to pick up pre-built binaries from a release location (currently in the releases of this repo). Moved the steps to build ovn-kubernetes into a separate script that can be run when new bits are available. 