### PR TITLE
Fixed cluster-DNS configuration for pods

### DIFF
--- a/init.ps1
+++ b/init.ps1
@@ -54,7 +54,7 @@ $serviceFileText=@"
       <name>kubelet</name>
       <description>This service runs kubelet.</description>
       <executable>C:\k\kubelet.exe</executable>
-      <arguments>--hostname-override=$(hostname) --v=6 $nodeIp --pod-infra-container-image=apprenda/pause --resolv-conf="" --allow-privileged=true --enable-debugging-handlers --cluster-dns=10.96.0.10 --cluster-domain=cluster.local --bootstrap-kubeconfig="C:\etc\kubernetes\bootstrap-kubelet.conf" --kubeconfig=c:\k\config --hairpin-mode=promiscuous-bridge --image-pull-progress-deadline=20m --cgroups-per-qos=false --enforce-node-allocatable="" --network-plugin=cni --cni-bin-dir="c:\cni" --cni-conf-dir "c:\cni-conf"</arguments>
+      <arguments>--hostname-override=$(hostname) --v=6 $nodeIp --pod-infra-container-image=apprenda/pause --resolv-conf="" --allow-privileged=true --enable-debugging-handlers --cluster-dns=172.16.1.10 --cluster-domain=cluster.local --bootstrap-kubeconfig="C:\etc\kubernetes\bootstrap-kubelet.conf" --kubeconfig=c:\k\config --hairpin-mode=promiscuous-bridge --image-pull-progress-deadline=20m --cgroups-per-qos=false --enforce-node-allocatable="" --network-plugin=cni --cni-bin-dir="c:\cni" --cni-conf-dir "c:\cni-conf"</arguments>
       <logmode>rotate</logmode>
 </service>
 "@

--- a/init.sh
+++ b/init.sh
@@ -124,6 +124,7 @@ END
 mkdir -p /etc/systemd/system/kubelet.service.d
 cd /etc/systemd/system/kubelet.service.d
 wget -q https://raw.githubusercontent.com/kubernetes/kubernetes/${k8sVersion}/build/debs/10-kubeadm.conf
+sed -i.bak 's/--cluster-dns=10.96.0.10/--cluster-dns=172.16.1.10/g' 10-kubeadm.conf
 
 systemctl enable kubelet
 


### PR DESCRIPTION
We were previously using the default DNS IP that came with kubeadm (10.96.0.10), which
didn't work with our selection of a cluster IP address range. The fix switches the IP to the IP for the kubedns service in our chosen range (172.16.1.10)

To test the fix : 
* Deploy a cluster
* Deploy a sample service  (e.g. my-nginx)
* Run a busybox pod, and run "nslookup my-nginx". The response should include the IP address of the service, e.g. 
/ # nslookup my-nginx
Server:    172.16.1.10
Address 1: 172.16.1.10 kube-dns.kube-system.svc.cluster.local

Name:      my-nginx
Address 1: 172.16.1.222 my-nginx.default.svc.cluster.local```
```