### PR TITLE
Added socat to base linux node install to support kubectl port-forward

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -27,7 +27,7 @@ sudo apt-get update
 
 apt-get install -y linux-headers-4.4.0-87-generic docker.io python-six apt-transport-https ca-certificates openssl \
  python-pip openvswitch-datapath-dkms=2.8.1-1 openvswitch-switch=2.8.1-1 openvswitch-common=2.8.1-1 \
- libopenvswitch=2.8.1-1 ovn-central=2.8.1-1 ovn-common=2.8.1-1 ovn-host=2.8.1-1
+ libopenvswitch=2.8.1-1 ovn-central=2.8.1-1 ovn-common=2.8.1-1 ovn-host=2.8.1-1 socat
 
 sudo apt-get build-dep dkms -y
 


### PR DESCRIPTION
Without socat being installed, port-forward complains about it and doesn't work .
```
kubectl port-forward my-nginx-66869769bd-9sv4n 8888:80
Forwarding from 127.0.0.1:8888 -> 80
Handling connection for 8888
d0d5f2b6dee340230c8405c68e8398153902a41265f6490c6745df8bae1cb738, uid : unable to do port forwarding: socat not found.
```